### PR TITLE
Add flannel manifest after init control plane & force use cgroup v1 even in ubuntu 22.04

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 ask_pass = True
+host_key_checking = False
 
 [privilege_escalation]
 become_ask_pass = True

--- a/roles/initialize/tasks/main.yml
+++ b/roles/initialize/tasks/main.yml
@@ -58,5 +58,5 @@
     regexp: "^PermitRootLogin"
     line: "PermitRootLogin no"
     state: present
-  notify: restart sshd
+  notify: Restart sshd
   become: True

--- a/roles/kubeadm-common/tasks/kubernetes.yml
+++ b/roles/kubeadm-common/tasks/kubernetes.yml
@@ -31,3 +31,37 @@
     state: present
     update_cache: True
   become: True
+
+# TIPS: 2022/07/19 - force use cgroup v1 because cgroup v2 & containerd & kubeadm 1.24 may ends up crashing kube-apiserver & etcd
+# cgroup v2 is default after ubuntu 21.10
+- name: Check if cgroup v1 is used
+  shell:
+    cmd: cat /etc/default/grub
+  register: grub_result
+  become: True
+
+- name: Force using cgroup v1 not cgroup v2
+  lineinfile:
+    dest: /etc/default/grub
+    state: present
+    regexp: "^GRUB_CMDLINE_LINUX_DEFAULT"
+    line: 'GRUB_CMDLINE_LINUX_DEFAULT="systemd.unified_cgroup_hierarchy=false"'
+  when: '"systemd.unified_cgroup_hierarchy=false" not in grub_result.stdout'
+  become: True
+
+- name: Update grub 
+  shell:
+    cmd: update-grub
+  when: '"systemd.unified_cgroup_hierarchy=false" not in grub_result.stdout'
+  become: True
+
+- name: Reboot node
+  reboot:
+    reboot_timeout: 300 # 5min
+  when: '"systemd.unified_cgroup_hierarchy=false" not in grub_result.stdout'
+  become: True
+
+- name: Set swapoff
+  command: swapoff -a
+  when: '"systemd.unified_cgroup_hierarchy=false" not in grub_result.stdout'
+  become: True

--- a/roles/kubeadm-control-plane/tasks/main.yml
+++ b/roles/kubeadm-control-plane/tasks/main.yml
@@ -19,8 +19,9 @@
   file:
     path: /home/ansible/.kube
     state: directory
+    owner: ansible
+    group: wheel
     mode: '0755'
-  become: True
 
 - name: Copy kubectl config from kubeadm init result
   copy:
@@ -32,8 +33,29 @@
     remote_src: yes
   become: True
 
+- name: Pause 30s while kube-apiserver starts running
+  pause:
+    seconds: 30
+
 # TIPS: without CNI, you will get `Network plugin returns error: cni plugin not initialized` log in kubelet's log
 # https://github.com/flannel-io/flannel#deploying-flannel-manually
+- name: Ensure /home/ansible/k8s exists
+  file:
+    path: /home/ansible/k8s
+    state: directory
+    owner: ansible
+    group: wheel
+    mode: '0755'
+  become: True
+
+- name: Generate flannel manifest from template
+  template:
+    src: kube-flannel.yml
+    dest: /home/ansible/k8s/kube-flannel.yml
+    owner: ansible
+    group: wheel
+    mode: '0644'
+
 - name: Apply flannel as kubernetes cni
   shell:
-    cmd: kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/0ef0e29b9e8eee08be9f06c0855cce6aac44de06/Documentation/kube-flannel.yml
+    cmd: kubectl apply -f /home/ansible/k8s/kube-flannel.yml

--- a/roles/kubeadm-control-plane/templates/kube-flannel.yml
+++ b/roles/kubeadm-control-plane/templates/kube-flannel.yml
@@ -1,0 +1,211 @@
+# https://github.com/flannel-io/flannel/blob/0ef0e29b9e8eee08be9f06c0855cce6aac44de06/Documentation/kube-flannel.yml
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: kube-flannel
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flannel
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-flannel
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flannel
+  namespace: kube-flannel
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-flannel
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "cniVersion": "0.3.1",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
+    }
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds
+  namespace: kube-flannel
+  labels:
+    tier: node
+    app: flannel
+spec:
+  selector:
+    matchLabels:
+      app: flannel
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: flannel
+      initContainers:
+      - name: install-cni-plugin
+       #image: flannelcni/flannel-cni-plugin:v1.1.0 for ppc64le and mips64le (dockerhub limitations may apply)
+        image: rancher/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
+        command:
+        - cp
+        args:
+        - -f
+        - /flannel
+        - /opt/cni/bin/flannel
+        volumeMounts:
+        - name: cni-plugin
+          mountPath: /opt/cni/bin
+      - name: install-cni
+       #image: flannelcni/flannel:v0.18.1 for ppc64le and mips64le (dockerhub limitations may apply)
+        image: rancher/mirrored-flannelcni-flannel:v0.18.1
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conflist
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      containers:
+      - name: kube-flannel
+       #image: flannelcni/flannel:v0.18.1 for ppc64le and mips64le (dockerhub limitations may apply)
+        image: rancher/mirrored-flannelcni-flannel:v0.18.1
+        command:
+        - /opt/bin/flanneld
+        args:
+        - --ip-masq
+        - --kube-subnet-mgr
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: false
+          capabilities:
+            add: ["NET_ADMIN", "NET_RAW"]
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        # specify service host if name is not reachable
+        # https://stackoverflow.com/questions/58194119/kubeadm-failed-to-create-subnetmanager-error-retrieving-pod-spec-for-kube-syste/60097567#60097567
+        - name: KUBERNETES_SERVICE_HOST
+          value: "{{control_plane_ip}}" #ip address of the host where kube-apiservice is running
+        - name: KUBERNETES_SERVICE_PORT
+          value: "6443"
+        - name: EVENT_QUEUE_DEPTH
+          value: "5000"
+        volumeMounts:
+        - name: run
+          mountPath: /run/flannel
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+        - name: xtables-lock
+          mountPath: /run/xtables.lock
+      volumes:
+      - name: run
+        hostPath:
+          path: /run/flannel
+      - name: cni-plugin
+        hostPath:
+          path: /opt/cni/bin
+      - name: cni
+        hostPath:
+          path: /etc/cni/net.d
+      - name: flannel-cfg
+        configMap:
+          name: kube-flannel-cfg
+      - name: xtables-lock
+        hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate


### PR DESCRIPTION
## Why

- We need to initialize cni after control plane init
- **kube-apisever & etcd restarted frequently after kubeadm init**. Maybe cgroup v2 affect running kubelet properly.
  - FYI: Quote from Japanese article [Ubuntu 22.04でkubeadmでKubernetesクラスターが動かない？ - 仮想化通信](https://tech.virtualtech.jp/entry/2022/06/08/115030)

You may get this kind of message in kubeadm init

`[WARNING SystemVerification]: missing optional cgroups: blkio`


```
ansible@node1:~$ sudo kubeadm init --control-plane-endpoint=xxxxx         --pod-network-cidr=10.244.0.0/16         --node-name=control-plane-1         --cri-socket=unix:///var/run/containerd/containerd.sock
[init] Using Kubernetes version: v1.24.2
[preflight] Running pre-flight checks
        [WARNING SystemVerification]: missing optional cgroups: blkio
        [WARNING Hostname]: hostname "control-plane-1" could not be reached
        [WARNING Hostname]: hostname "control-plane-1": lookup control-plane-1 on 127.0.0.53:53: server misbehaving
[preflight] Pulling images required for setting up a Kubernetes cluster
[preflight] This might take a minute or two, depending on the speed of your internet connection
[preflight] You can also perform this action in beforehand using 'kubeadm config images pull'
[certs] Using certificateDir folder "/etc/kubernetes/pki"
```

## What

- add flannel manifest to initialize cni
- force use cgroup v1 in ubuntu 22.04

## QA

```
$ ansible-playbook -i hosts.yml --limit control_plane1 k8s-control-plane.yml
SSH password: 
BECOME password[defaults to SSH password]: 

PLAY [k8s_control_planes] ********************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Update apt packages list for getting cache] ***************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Set swapoff] **********************************************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Enable overlay module] ************************************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Enable br_netfilter module] *******************************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Load kernel module when machine started] ******************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Set sysctl params when machine started] *******************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Check netfilter option configured as expected] ************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Check containerd already installed] ***********************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Download and extract containerd tar] **********************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-common : Ensure /usr/local/lib/systemd/system exists] **************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Download containerd systemctl service file] ***************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Check nerdctl already installed] **************************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Install nerdctl] ******************************************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-common : Check runc already installed] *****************************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Download runc] ********************************************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-common : Install runc] *********************************************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-common : Remove runc.amd64 file] ***********************************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-common : Ensure /opt/cni/bin exists] *******************************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Check cni plugins already installed] **********************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Download and extract cni plugins] *************************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-common : Enable containerd systemctl service] **********************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Install required libraries] *******************************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Download the Google Cloud public signing key] *************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Add kubernetes apt list] **********************************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Install commands required in kubernetes] ******************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-common : Check if cgroup v1 is used] *******************************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-common : Force using cgroup v1 not cgroup v2] **********************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-common : Update grub] **********************************************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-common : Reboot node] **********************************************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-common : Set swapoff] **********************************************************************************************************************************
skipping: [machine_control_plane1]

TASK [kubeadm-control-plane : Reset kubeadm] *************************************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-control-plane : Start kubernetes control plane] ********************************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-control-plane : Ensure /home/ansible/.kube exists] *****************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-control-plane : Copy kubectl config from kubeadm init result] ******************************************************************************************
changed: [machine_control_plane1]

TASK [kubeadm-control-plane : Pause 30s while kube-apiserver starts running] *****************************************************************************************
Pausing for 30 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [machine_control_plane1]

TASK [kubeadm-control-plane : Ensure /home/ansible/k8s exists] *******************************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-control-plane : Generate flannel manifest from template] ***********************************************************************************************
ok: [machine_control_plane1]

TASK [kubeadm-control-plane : Apply flannel as kubernetes cni] *******************************************************************************************************
changed: [machine_control_plane1]

PLAY RECAP ***********************************************************************************************************************************************************
machine_control_plane1     : ok=29   changed=14   unreachable=0    failed=0    skipped=10   rescued=0    ignored=0   
```

### k8s 1.24 running stable

```
ansible@node1:~$ kubectl get pods -A
NAMESPACE      NAME                                      READY   STATUS    RESTARTS   AGE
kube-flannel   kube-flannel-ds-6zfkv                     1/1     Running   0          3m14s
kube-system    coredns-6d4b75cb6d-ll4mw                  1/1     Running   0          3m32s
kube-system    coredns-6d4b75cb6d-wtdb9                  1/1     Running   0          3m32s
kube-system    etcd-control-plane-1                      1/1     Running   1283       3m48s
kube-system    kube-apiserver-control-plane-1            1/1     Running   166        3m47s
kube-system    kube-controller-manager-control-plane-1   1/1     Running   281        3m48s
kube-system    kube-proxy-c9ndp                          1/1     Running   0          3m32s
kube-system    kube-scheduler-control-plane-1            1/1     Running   266        3m47s

ansible@node1:~$ kubectl get nodes
NAME              STATUS   ROLES           AGE     VERSION
control-plane-1   Ready    control-plane   3m54s   v1.24.2

```