### PR TITLE
Remove installation of traefik because we install nginx ing controller

### DIFF
--- a/roles/k3s-control-plane/tasks/main.yml
+++ b/roles/k3s-control-plane/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Install k3s if not installed
   when: "not k3s_binary_stats.stat.exists"
   shell:
-    cmd: "curl -sfL https://get.k3s.io | sh -"
+    cmd: "curl -sfL https://get.k3s.io | sh -s - --disable traefik"
   register: k3s_installation_result
   failed_when: '"systemd: Starting k3s" not in k3s_installation_result.stdout'
 

--- a/roles/k3s-worker/tasks/main.yml
+++ b/roles/k3s-worker/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: Install k3s if not installed
   when: "not k3s_binary_stats.stat.exists"
   shell:
-    cmd: "curl -sfL https://get.k3s.io | K3S_URL=https://{{ hostvars.machine_control_plane1.ansible_host }}:6443 K3S_TOKEN={{ k3s_node_token }} sh -"
+    cmd: "curl -sfL https://get.k3s.io | K3S_URL=https://{{ hostvars.machine_control_plane1.ansible_host }}:6443 K3S_TOKEN={{ k3s_node_token }} sh -s - --disable traefik"
   register: k3s_installation_result
   failed_when: '"systemd: Starting k3s" not in k3s_installation_result.stdout'
 


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- traefik controller cause race condition of ports between nginx-ingress-controller

## What
<!-- What features are added in this PR -->
- we use nginx-ingress-controller so uninstall traefik by defalt

## QA

- [x] tried install k3s with wsl2 ubuntu

```console
root@akisur:~# curl -sfL https://get.k3s.io | sh -s - --disable traefik
[INFO]  Finding release for channel stable
[INFO]  Using v1.31.4+k3s1 as release
[INFO]  Downloading hash https://github.com/k3s-io/k3s/releases/download/v1.31.4+k3s1/sha256sum-amd64.txt
[INFO]  Downloading binary https://github.com/k3s-io/k3s/releases/download/v1.31.4+k3s1/k3s
[INFO]  Verifying binary download
[INFO]  Installing k3s to /usr/local/bin/k3s
[INFO]  Skipping installation of SELinux RPM
[INFO]  Creating /usr/local/bin/kubectl symlink to k3s
[INFO]  Creating /usr/local/bin/crictl symlink to k3s
[INFO]  Creating /usr/local/bin/ctr symlink to k3s
[INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
[INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
[INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
[INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
[INFO]  systemd: Enabling k3s unit
Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
[INFO]  Host iptables-save/iptables-restore tools not found
[INFO]  Host ip6tables-save/ip6tables-restore tools not found
[INFO]  systemd: Starting k3s


root@akisur:~# k3s
NAME:
   k3s - Kubernetes, but small and simple

USAGE:
   k3s [global options] command [command options] [arguments...]



root@akisur:~# cat /etc/systemd/system/k3s.service
[Unit]
Description=Lightweight Kubernetes
Documentation=https://k3s.io
Wants=network-online.target
After=network-online.target

[Install]
WantedBy=multi-user.target

[Service]
Type=notify
EnvironmentFile=-/etc/default/%N
EnvironmentFile=-/etc/sysconfig/%N
EnvironmentFile=-/etc/systemd/system/k3s.service.env
KillMode=process
Delegate=yes
# Having non-zero Limit*s causes performance problems due to accounting overhead
# in the kernel. We recommend using cgroups to do container-local accounting.
LimitNOFILE=1048576
LimitNPROC=infinity
LimitCORE=infinity
TasksMax=infinity
TimeoutStartSec=0
Restart=always
RestartSec=5s
ExecStartPre=/bin/sh -xc '! /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service 2>/dev/null'
ExecStartPre=-/sbin/modprobe br_netfilter
ExecStartPre=-/sbin/modprobe overlay
ExecStart=/usr/local/bin/k3s \
    server \
        '--disable' \
        'traefik' \
```

## Notes

- [Configuration Options \| K3s](https://docs.k3s.io/installation/configuration#configuration-with-install-script)

we can use skip file but we need to put it before k3s installation
- [Managing Packaged Components \| K3s](https://docs.k3s.io/installation/packaged-components?_highlight=disable&_highlight=traef#using-skip-files)