### PR TITLE
upgrade k8s with system-upgrade-controller when 1 node is not ready

### DIFF
--- a/roles/system-upgrade-controller/files/k8s-upgrade-plan.yaml
+++ b/roles/system-upgrade-controller/files/k8s-upgrade-plan.yaml
@@ -14,6 +14,10 @@ spec:
         operator: In
         values:
           - "true"
+      - key: node.kubernetes.io/unreachable
+        operator: DoesNotExist
+      - key: node.kubernetes.io/not-ready
+        operator: DoesNotExist
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
@@ -26,11 +30,15 @@ metadata:
   name: agent-plan
   namespace: system-upgrade
 spec:
-  concurrency: 1
+  concurrency: 2
   cordon: true
   nodeSelector:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+      - key: node.kubernetes.io/unreachable
+        operator: DoesNotExist
+      - key: node.kubernetes.io/not-ready
         operator: DoesNotExist
   prepare:
     args:

--- a/roles/system-upgrade-controller/files/k8s-upgrade-plan.yaml
+++ b/roles/system-upgrade-controller/files/k8s-upgrade-plan.yaml
@@ -14,10 +14,6 @@ spec:
         operator: In
         values:
           - "true"
-      - key: node.kubernetes.io/unreachable
-        operator: DoesNotExist
-      - key: node.kubernetes.io/not-ready
-        operator: DoesNotExist
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade
@@ -30,15 +26,11 @@ metadata:
   name: agent-plan
   namespace: system-upgrade
 spec:
-  concurrency: 2
+  concurrency: 3
   cordon: true
   nodeSelector:
     matchExpressions:
       - key: node-role.kubernetes.io/control-plane
-        operator: DoesNotExist
-      - key: node.kubernetes.io/unreachable
-        operator: DoesNotExist
-      - key: node.kubernetes.io/not-ready
         operator: DoesNotExist
   prepare:
     args:


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- when we have a node that is not ready, system-ugrade-controller will stuck

```console
system-upgrade        apply-agent-plan-on-node3-with-c5a1f5b354df7de6ba2ed731bd-8prdp   0/1   Pending             0   0   0    n/a n/a
```

## What
<!-- What features are added in this PR -->
- update concurrency to 3

### can we ignore NotReady nodes?

No, I suppose. I tried matchexpressions below but didnt work.

```
      - key: node.kubernetes.io/unreachable
        operator: DoesNotExist
      - key: node.kubernetes.io/not-ready
        operator: DoesNotExist
```

node label ` node.kubernetes.io/unreachable`  does not exist because unreachable is Taint and not Label

```yaml
kind: Node
metadata:
  annotations:
    k3s.io/hostname: node1
    k3s.io/node-args: '["server","--disable","traefik"]'
  finalizers:
  - wrangler.cattle.io/node
  labels:
    beta.kubernetes.io/arch: amd64
    beta.kubernetes.io/instance-type: k3s
    beta.kubernetes.io/os: linux
    kubernetes.io/arch: amd64
    kubernetes.io/hostname: node1
    kubernetes.io/os: linux
    node-role.kubernetes.io/control-plane: "true"
    node-role.kubernetes.io/master: "true"
    node.kubernetes.io/instance-type: k3s
  name: node1
``` 


## QA, Evidence
<!-- Things that support this PR is correct -->
- [x] applied to a cluster and checked if working fine

